### PR TITLE
Snapshot-Only Completion, Configurable Dirs, Shared Stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
-# SyncLite Validator — End-to-End Integration Testing Tool
+﻿# SyncLite Validator – End-to-End Integration Testing Tool
 
-> Part of the [SyncLite Platform](https://github.com/syncliteio/SyncLite) — Build Anything, Sync Anywhere.
+> Part of the [SyncLite Platform](https://github.com/syncliteio/SyncLite) – Build Anything, Sync Anywhere.
 
 ## What is SyncLite Validator?
 
-**SyncLite Validator** is the end-to-end (E2E) integration testing and data quality verification tool for SyncLite pipelines. It drives synthetic workloads through the full SyncLite pipeline — from edge device through staging storage through consolidation into the destination — and automatically validates that every row, every transaction, and every schema change arrived correctly and in the expected state.
+**SyncLite Validator** is the end-to-end (E2E) integration testing and data quality verification tool for SyncLite pipelines. It drives synthetic workloads through the full SyncLite pipeline – from edge device through staging storage through consolidation into the destination – and automatically validates that every row, every transaction, and every schema change arrived correctly and in the expected state.
 
 It is used by SyncLite developers for regression testing of the platform and by adopters to verify their pipeline configuration before going to production.
 
 ```
 Validator (workload generator)
-       │  SQL operations via SyncLite Logger / SyncLite DB
+       |  SQL operations via SyncLite Logger / SyncLite DB
        ▼
-  Edge Device  ──▶  Staging Storage  ──▶  SyncLite Consolidator  ──▶  Destination DB
-       │                                                                      │
-       └──────────────── Validator (data comparison) ◀────────────────────────┘
+  Edge Device  -->  Staging Storage  -->  SyncLite Consolidator  -->  Destination DB
+       |                                                                      |
+       +------------------- Validator (data comparison) <---------------------+
 ```
 
 ## Key Features
 
-- **Automated E2E verification** — generates a configurable workload, waits for consolidation, then compares source and destination row by row
-- **Multiple device types** — validates all SyncLite device types (SQLite, DuckDB, Derby, H2, HyperSQL, Streaming)
-- **Schema evolution testing** — validates DDL changes (ALTER TABLE, new tables) propagate correctly
-- **Transaction integrity** — verifies committed vs. rolled-back transactions are reflected correctly at the destination
-- **Configurable workloads** — control table count, row count, update/delete ratios, and concurrency
-- **Detailed diff reports** — row-level mismatch reports with source vs. destination values
-- **Web UI** — configure test runs, view progress, and inspect results from a browser
+- **Automated E2E verification** – generates a configurable workload, waits for consolidation, then compares source and destination row by row
+- **Multiple device types** – validates all SyncLite device types (SQLite, DuckDB, Derby, H2, HyperSQL, Streaming)
+- **Schema evolution testing** – validates DDL changes (ALTER TABLE, new tables) propagate correctly
+- **Transaction integrity** – verifies committed vs. rolled-back transactions are reflected correctly at the destination
+- **Configurable workloads** – control table count, row count, update/delete ratios, and concurrency
+- **Detailed diff reports** – row-level mismatch reports with source vs. destination values
+- **Web UI** – configure test runs, view progress, and inspect results from a browser
 
 ## Quick Start
 
@@ -60,4 +60,5 @@ Built WAR: `root/web/target/synclite-validator-oss.war`
 
 ---
 
-← Back to the [SyncLite Platform README](https://github.com/syncliteio/SyncLite/blob/main/README.md)
+↑ Back to the [SyncLite Platform README](https://github.com/syncliteio/SyncLite/blob/main/README.md)
+

--- a/root/core/.classpath
+++ b/root/core/.classpath
@@ -23,7 +23,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/synclite/SyncLiteWorkspaces/SyncLiteDistributions/SyncLite/synclite-logger-java/logger/target/synclite-logger-oss.jar"/>
+	<classpathentry kind="lib" path="C:/synclite/SyncLiteWorkspaces/SyncLiteDistributions/SyncLite/synclite-logger-java/logger/target/synclite-oss.jar"/>
 	<classpathentry excluding="**" kind="src" output="target/classes" path="config">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/root/core/pom.xml
+++ b/root/core/pom.xml
@@ -15,6 +15,7 @@
 	</parent>
 
 	<properties>
+		<revision>oss</revision>
 		<synclite-logger.version>${revision}</synclite-logger.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>11</maven.compiler.source>
@@ -191,7 +192,7 @@
 
 		<dependency>
 			<groupId>io.synclite</groupId>
-			<artifactId>synclite-logger</artifactId>
+			<artifactId>synclite</artifactId>
 			<version>${synclite-logger.version}</version>
 		</dependency>
 

--- a/root/core/src/main/java/com/synclite/validator/TestDriver.java
+++ b/root/core/src/main/java/com/synclite/validator/TestDriver.java
@@ -110,6 +110,10 @@ public class TestDriver implements Runnable{
 	private static final String DEVICE_COMMIT_ID_READER_QUERY = "SELECT MAX(commit_id) FROM synclite_txn";
 	private static final Long CONSOLIDATION_WAIT_DURATION_MS = 600000L;
 	private static final Long CONSOLIDATION_CHECK_INTERVAL = 5000L;
+	// Number of consecutive polls where the destination synclite_metadata row is
+	// missing (-1) before we conclude the device was consolidated solely via the
+	// initial snapshot path (no CDC ops applied -> no metadata row inserted).
+	private static final int SNAPSHOT_ONLY_SETTLE_POLLS = 6;
 	private static final Long CONSOLIDATOR_JOB_WAIT_DURATION_MS = 300000L;
 
 	public TestDriver(Path testRoot, Path loggerConfig, Path consolidatorConfig, Path corePath, Integer nThr) throws SyncLiteTestException {
@@ -117,7 +121,9 @@ public class TestDriver implements Runnable{
 		this.loggerConfig = loggerConfig;		
 		this.consolidatorConfig = consolidatorConfig;
 		this.corePath = corePath;
-		this.dbDir = testRoot.resolve("db");
+		// All device directories created by the validator live under db/validator/
+		// so they coexist with sibling projects (db/rustologger, db/javalogger, ...).
+		this.dbDir = testRoot.resolve("db").resolve("validator");
 		this.stageDir = testRoot.resolve("stageDir");
 		this.workDir = testRoot.resolve("workDir");
 		this.commandDir = testRoot.resolve("commandDir");
@@ -364,7 +370,7 @@ public class TestDriver implements Runnable{
 		this.dbreaderSrcDbPath  = dbreaderSrcDbDir.resolve("source.db");
 		this.dbreaderConfigPath = dbreaderDbDir.resolve("synclite_dbreader.conf");
 		Path dbreaderMetaDbPath = dbreaderDbDir.resolve("synclite_dbreader_metadata.db");
-		Path dbreaderLoggerConf = dbreaderDbDir.resolve("synclite_logger.conf");
+		Path dbreaderLoggerConf = dbreaderDbDir.resolve("synclite.conf");
 
 		try {
 			// Clean up any stale dbreader state from a previous run
@@ -567,7 +573,7 @@ public class TestDriver implements Runnable{
 		this.qreaderDbDir = qreaderTestRoot.resolve("db");
 		this.qreaderConfigPath = qreaderDbDir.resolve("synclite-qreader.conf");
 		Path qreaderMetaDbPath = qreaderDbDir.resolve("synclite_qreader_metadata.db");
-		this.qreaderLoggerConf = qreaderDbDir.resolve("synclite_logger.conf");
+		this.qreaderLoggerConf = qreaderDbDir.resolve("synclite.conf");
 		this.qreaderDeviceDbPath = qreaderDbDir.resolve(QREADER_DEVICE_NAME + ".db");
 
 		try {
@@ -1217,6 +1223,7 @@ public class TestDriver implements Runnable{
 			long waited = 0;
 			long deviceCommitID = 0;
 			long dstCommitID = 0;
+			int consecutiveMissingDstRow = 0;
 			while (waited <= CONSOLIDATION_WAIT_DURATION_MS) {
 				DBReader deviceDBReader;
 				Properties props = new Properties();
@@ -1237,12 +1244,30 @@ public class TestDriver implements Runnable{
 				String dstCommitIDQuery = "SELECT commit_id FROM " + this.dstTablePrefix + "synclite_metadata WHERE synclite_device_name = '" + deviceName + "'";
 				dstCommitID = dstDBReader.readScalarLong(dstCommitIDQuery);
 
-				if (deviceCommitID == dstCommitID) {
+				// Accept if destination has caught up to or past the device's last commit.
+				if (dstCommitID >= deviceCommitID && dstCommitID > 0) {
 					return;
-				} else {
-					Thread.sleep(CONSOLIDATION_CHECK_INTERVAL);
-					waited += CONSOLIDATION_CHECK_INTERVAL;
 				}
+
+				// Snapshot-only path: when device data is consolidated solely via the
+				// snapshot, no synclite_metadata row is inserted for this device on the
+				// destination, so dstCommitID stays -1 forever. Detect this case after a
+				// short settling window and let downstream data verification check the
+				// actual rows.
+				if (dstCommitID == -1) {
+					++consecutiveMissingDstRow;
+					if (consecutiveMissingDstRow >= SNAPSHOT_ONLY_SETTLE_POLLS) {
+						globalTracer.debug("No synclite_metadata row found for device " + deviceName
+								+ " after " + consecutiveMissingDstRow + " polls; assuming snapshot-only consolidation."
+								+ " Device last commit_id=" + deviceCommitID);
+						return;
+					}
+				} else {
+					consecutiveMissingDstRow = 0;
+				}
+
+				Thread.sleep(CONSOLIDATION_CHECK_INTERVAL);
+				waited += CONSOLIDATION_CHECK_INTERVAL;
 			}
 			throw new SyncLiteTestException("Data consolidation did not finish in " + CONSOLIDATION_WAIT_DURATION_MS + " (ms). Last read CommitID from device : " + deviceCommitID + ". Last read CommitID from destination : " + dstCommitID);
 		} catch (InterruptedException e) {
@@ -1256,6 +1281,7 @@ public class TestDriver implements Runnable{
 			long waited = 0;
 			long deviceCommitID = 0;
 			long dstCommitID = 0;
+			int consecutiveMissingDstRow = 0;
 			while (waited <= CONSOLIDATION_WAIT_DURATION_MS) {
 				try {
 					SyncLiteDBResult r = executeSQL(deviceName, null, DEVICE_COMMIT_ID_READER_QUERY, null);
@@ -1279,12 +1305,24 @@ public class TestDriver implements Runnable{
 				String dstCommitIDQuery = "SELECT commit_id FROM " + this.dstTablePrefix + "synclite_metadata WHERE synclite_device_name = '" + deviceName + "'";
 				dstCommitID = dstDBReader.readScalarLong(dstCommitIDQuery);
 
-				if (deviceCommitID == dstCommitID) {
+				if (dstCommitID >= deviceCommitID && dstCommitID > 0) {
 					return;
-				} else {
-					Thread.sleep(CONSOLIDATION_CHECK_INTERVAL);
-					waited += CONSOLIDATION_CHECK_INTERVAL;
 				}
+
+				if (dstCommitID == -1) {
+					++consecutiveMissingDstRow;
+					if (consecutiveMissingDstRow >= SNAPSHOT_ONLY_SETTLE_POLLS) {
+						globalTracer.debug("No synclite_metadata row found for device " + deviceName
+								+ " after " + consecutiveMissingDstRow + " polls; assuming snapshot-only consolidation."
+								+ " Device last commit_id=" + deviceCommitID);
+						return;
+					}
+				} else {
+					consecutiveMissingDstRow = 0;
+				}
+
+				Thread.sleep(CONSOLIDATION_CHECK_INTERVAL);
+				waited += CONSOLIDATION_CHECK_INTERVAL;
 			}
 			throw new SyncLiteTestException("Data consolidation did not finish in " + CONSOLIDATION_WAIT_DURATION_MS + " (ms). Last read CommitID from device : " + deviceCommitID + ". Last read CommitID from destination : " + dstCommitID);
 		} catch (InterruptedException e) {
@@ -3133,7 +3171,7 @@ public class TestDriver implements Runnable{
 				store.insert(tableName, java.util.Map.of("id", 5, "name", "eve", "score", 500));
 
 				// Test rollback: rolled-back transaction must NOT appear in destination.
-				// Product bug: SyncLiteStore.rollback() currently does not suppress the log entry —
+				// Product bug: SyncLiteStore.rollback() currently does not suppress the log entry –
 				// the rolled-back row (id=99) is staged with a valid commit_id and replayed by the
 				// consolidator. If this test fails, use dumpStageDirCommandLog output to confirm.
 				store.setAutoCommit(false);
@@ -3146,7 +3184,7 @@ public class TestDriver implements Runnable{
 			try {
 				waitForConsolidation(testName, DeviceType.SQLITE_STORE, testDBPath);
 			} catch (SyncLiteTestException waitEx) {
-				globalTracer.error("[" + testName + "] waitForConsolidation timed out — dumping diagnostics");
+				globalTracer.error("[" + testName + "] waitForConsolidation timed out – dumping diagnostics");
 				dumpStageDirCommandLog(testName, 30);
 				dumpConsolidatorTrace(testName, 40);
 				throw waitEx;
@@ -3250,7 +3288,7 @@ public class TestDriver implements Runnable{
 					Jedis jedis = Jedis.builder(store).host(redisHost).port(redisPort).build()) {
 				jedis.set(keyPrefix + "k1", "v1");
 				jedis.rpush(keyPrefix + "list1", "a", "b");
-				// Test hash operations — jedis_hashes has composite PK (hash_key, field).
+				// Test hash operations – jedis_hashes has composite PK (hash_key, field).
 				// Known issue: consolidator throws "table has more than one primary key" when
 				// seeding in-memory replica for jedis_hashes. dumpConsolidatorTrace will capture
 				// the exact exception if waitForConsolidation times out.
@@ -3261,7 +3299,7 @@ public class TestDriver implements Runnable{
 			try {
 				waitForConsolidation(testName, DeviceType.SQLITE_STORE, testDBPath);
 			} catch (SyncLiteTestException waitEx) {
-				globalTracer.error("[" + testName + "] waitForConsolidation timed out — dumping diagnostics");
+				globalTracer.error("[" + testName + "] waitForConsolidation timed out – dumping diagnostics");
 				dumpStageDirCommandLog(testName, 30);
 				dumpConsolidatorTrace(testName, 60);
 				throw waitEx;
@@ -4442,7 +4480,7 @@ public class TestDriver implements Runnable{
 				globalTracer.debug("Skipping idempotency toggle in " + testName + ": config file missing at " + runtimeConsolidatorConfigPath);
 			}
 
-			// ── Phase 1: 3 initial rows replicated ───────────────────────────
+			// –– Phase 1: 3 initial rows replicated –––––––––––––––––––––––––––
 			waitForDbreaderReplicationRowCount(dbReaderTable, 3);
 			// Spot-check key columns on row id=1
 			List<String> colText = dstDBReader.readRows(
@@ -4456,7 +4494,7 @@ public class TestDriver implements Runnable{
 				throw new SyncLiteTestException("Phase 1: expected col_bigint=9000000000 for id=1, got: " + colBigint);
 			}
 
-			// ── Phase 2: UPDATE row id=2 ─────────────────────────────────────
+			// –– Phase 2: UPDATE row id=2 –––––––––––––––––––––––––––––––––––––
 			try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + dbreaderSrcDbPath);
 					Statement stmt = conn.createStatement()) {
 				stmt.execute(
@@ -4472,7 +4510,7 @@ public class TestDriver implements Runnable{
 				throw new SyncLiteTestException("Phase 2: expected col_int=999 for id=2, got: " + colInt);
 			}
 
-			// ── Phase 3: Soft-DELETE row id=3 ────────────────────────────────
+			// –– Phase 3: Soft-DELETE row id=3 ––––––––––––––––––––––––––––––––
 			try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + dbreaderSrcDbPath);
 					Statement stmt = conn.createStatement()) {
 				stmt.execute(
@@ -5336,8 +5374,8 @@ public class TestDriver implements Runnable{
 		try {
 			preTest(testName);
 
-			// ── publish 3 test messages via MQTT ─────────────────────────────────
-			// Topic format: <deviceName>/<topicName> — matches header-delimiter = /
+			// –– publish 3 test messages via MQTT –––––––––––––––––––––––––––––––––
+			// Topic format: <deviceName>/<topicName> – matches header-delimiter = /
 			String mqttTopic = QREADER_DEVICE_NAME + "/" + QREADER_TABLE;
 			String clientId = "synclite-validator-" + UUID.randomUUID();
 			try (MqttClient mqttClient = new MqttClient(MQTT_BROKER_URL, clientId, new MemoryPersistence())) {
@@ -5355,7 +5393,7 @@ public class TestDriver implements Runnable{
 				mqttClient.disconnect();
 			}
 
-			// ── wait for all 3 rows to appear in the consolidated destination ───
+			// –– wait for all 3 rows to appear in the consolidated destination –––
 			Thread.sleep(2000);
 			long qreaderCommitId = 0;
 			if (Files.exists(qreaderDeviceDbPath)) {
@@ -5384,7 +5422,7 @@ public class TestDriver implements Runnable{
 
 			waitForDbreaderReplicationRowCount(QREADER_TABLE, 3);
 
-			// ── spot-check the first message's col1 value ────────────────────────
+			// –– spot-check the first message's col1 value ––––––––––––––––––––––––
 			List<String> col1Values = dstDBReader.readRows(
 				"SELECT col1 FROM " + this.dstTablePrefix + QREADER_TABLE + " ORDER BY col1");
 			if (col1Values.isEmpty() || !col1Values.contains("val1_col1")) {

--- a/root/pom.xml
+++ b/root/pom.xml
@@ -5,6 +5,9 @@
 	<groupId>com.synclite.validator</groupId>
 	<artifactId>root</artifactId>
 	<version>${revision}</version>
+	<properties>
+		<revision>oss</revision>
+	</properties>
 	<packaging>pom</packaging>
 
 

--- a/root/web/pom.xml
+++ b/root/web/pom.xml
@@ -5,11 +5,15 @@
 	<groupId>com.synclite.validator</groupId>
 	<artifactId>synclite-validator</artifactId>
 	<version>${revision}</version>
+	<properties>
+		<revision>oss</revision>
+	</properties>
 	<packaging>war</packaging>
 	<parent>
 		<groupId>com.synclite.validator</groupId>
 		<artifactId>root</artifactId>
 		<version>${revision}</version>
+	
 	</parent>
 	<build>
 		<plugins>

--- a/root/web/src/main/java/com/synclite/validator/web/ValidateJobConfiguration.java
+++ b/root/web/src/main/java/com/synclite/validator/web/ValidateJobConfiguration.java
@@ -81,49 +81,61 @@ public class ValidateJobConfiguration extends HttpServlet {
 			doGet(request, response);
 
 			String testRoot = request.getParameter("test-root");
+			String stageDirParam = request.getParameter("stage-dir");
+			String workDirParam = request.getParameter("work-dir");
 
 			Path testRootPath, stageDirPath, commandDirPath, dbDirPath, workDirPath;
 			if ((testRoot == null) || testRoot.trim().isEmpty()) {
 				throw new ServletException("\"Test Root\" must be specified");
 			} else {
 				testRootPath = Path.of(testRoot);
-				if (! Files.exists(testRootPath)) {
-					throw new ServletException("Specified \"Test Root\" : " + testRoot + " does not exist, please specify a valid \"Data Directory\"");
+				// Auto-create test root if it doesn't exist
+				Files.createDirectories(testRootPath);
+
+				if (! testRootPath.toFile().canRead()) {
+					throw new ServletException("Specified \"Test Directory\" does not have read permission");
+				}
+
+				if (! testRootPath.toFile().canWrite()) {
+					throw new ServletException("Specified \"Test Directory\" does not have write permission");
+				}
+
+				// Resolve stage and work dirs from form (with defaults under testRoot)
+				if ((stageDirParam != null) && !stageDirParam.trim().isEmpty()) {
+					stageDirPath = Path.of(stageDirParam);
 				} else {
-					if (! testRootPath.toFile().canRead()) {
-						throw new ServletException("Specified \"Test Directory\" does not have read permission");
-					}
-
-					if (! testRootPath.toFile().canWrite()) {
-						throw new ServletException("Specified \"Test Directory\" does not have write permission");
-					}
-
-					//Delete existing directory if present and recreate	
-					if (Files.exists(testRootPath)) {
-						// Delete all the files and subdirectories in the directory
-						Files.walk(testRootPath)
-						.sorted((p1, p2) -> -p1.compareTo(p2))
-						.forEach(path -> {
-							try {
-								Files.delete(path);
-							} catch (Exception e) {
-								e.printStackTrace();
-							}
-						});
-					}
-
-					//Create db, workDir and testDir if not present 
 					stageDirPath = Path.of(testRootPath.toString(), "stageDir");
-					commandDirPath = Path.of(testRootPath.toString(), "commandDir");
-					workDirPath = Path.of(testRootPath.toString(),"workDir");
-					dbDirPath = Path.of(testRootPath.toString(),"db");
-					//Delete existing directory if present and recreate	
+				}
+				if ((workDirParam != null) && !workDirParam.trim().isEmpty()) {
+					workDirPath = Path.of(workDirParam);
+				} else {
+					workDirPath = Path.of(testRootPath.toString(), "workDir");
+				}
+				dbDirPath = Path.of(testRootPath.toString(), "db", "validator");
+				commandDirPath = Path.of(testRootPath.toString(), "commandDir");
 
-					Files.createDirectories(dbDirPath);
-					Files.createDirectories(stageDirPath);
-					Files.createDirectories(commandDirPath);
-					Files.createDirectories(workDirPath);
-				} 
+				// Clean validator-owned directories only (db, commandDir, workDir).
+				// stageDir is shared across projects so do NOT wipe it wholesale;
+				// the consolidator handles per-device staging cleanup at runtime.
+				for (Path p : new Path[] { dbDirPath, commandDirPath, workDirPath }) {
+					if (Files.exists(p)) {
+						Files.walk(p)
+							.sorted((p1, p2) -> -p1.compareTo(p2))
+							.forEach(path -> {
+								try {
+									Files.delete(path);
+								} catch (Exception e) {
+									e.printStackTrace();
+								}
+							});
+					}
+				}
+
+				// Create all required directories
+				Files.createDirectories(dbDirPath);
+				Files.createDirectories(stageDirPath);
+				Files.createDirectories(commandDirPath);
+				Files.createDirectories(workDirPath);
 			}
 
 			String testNumThreadsStr = request.getParameter("test-num-threads");

--- a/root/web/src/main/webapp/configureTestJob.jsp
+++ b/root/web/src/main/webapp/configureTestJob.jsp
@@ -42,14 +42,21 @@ Path testRoot, dbPath,stageDirPath, workDirPath;
 
 if (request.getAttribute("test-root") != null) {
 	testRoot = Path.of(request.getAttribute("test-root").toString());
-	dbPath = Path.of(testRoot.toString(), "db");
-	stageDirPath = Path.of(testRoot.toString(), "stageDir");
-	workDirPath = Path.of(testRoot.toString(), "workDir");	
 } else {
-	testRoot = Path.of(System.getProperty("user.home"), "synclite", "test");
-	dbPath = Path.of(System.getProperty("user.home"), "synclite", "test", "db");
-	stageDirPath = Path.of(System.getProperty("user.home"), "synclite", "test", "stageDir");
-	workDirPath = Path.of(System.getProperty("user.home"), "synclite", "test", "workDir");
+	testRoot = Path.of(System.getProperty("user.home"), "synclite", "tests");
+}
+dbPath = testRoot.resolve("db").resolve("validator");
+
+if (request.getAttribute("stage-dir") != null) {
+	stageDirPath = Path.of(request.getAttribute("stage-dir").toString());
+} else {
+	stageDirPath = testRoot.resolve("stageDir");
+}
+
+if (request.getAttribute("work-dir") != null) {
+	workDirPath = Path.of(request.getAttribute("work-dir").toString());
+} else {
+	workDirPath = testRoot.resolve("workDir");
 }
 
 Integer numThreads = 0;
@@ -159,8 +166,26 @@ try {
 						<td>Test Directory</td>
 						<td><input type="text" size=30 id="test-root"
 							name="test-root"
-							value="<%=testRoot%>" readonly
-							title="Specify a work directory for SyncLite Validator."/>
+							value="<%=testRoot%>"
+							title="Specify a work directory for SyncLite Validator. Will be created if missing."/>
+						</td>
+					</tr>
+
+					<tr>
+						<td>Stage Directory</td>
+						<td><input type="text" size=30 id="stage-dir"
+							name="stage-dir"
+							value="<%=stageDirPath%>"
+							title="Specify the stage directory. Will be created if missing."/>
+						</td>
+					</tr>
+
+					<tr>
+						<td>Work Directory</td>
+						<td><input type="text" size=30 id="work-dir"
+							name="work-dir"
+							value="<%=workDirPath%>"
+							title="Specify the work directory. Will be created if missing."/>
 						</td>
 					</tr>
 


### PR DESCRIPTION
# synclite-validator — Snapshot-Only Completion, Configurable Dirs, Shared Stage

## Summary

Three independent improvements to the SyncLite Validator:

1. The "wait until consolidated" loop in `TestDriver` now correctly
   handles the **snapshot-only consolidation** path (device data is
   replayed entirely from the snapshot, so the destination
   `synclite_metadata` row never receives a commit-id update).
2. The configure-test-job UI now exposes the stage and work directories
   as form fields (previously hard-coded under the test root), and the
   servlet auto-creates the test root rather than rejecting a missing
   directory.
3. The validator's per-device DB directories now live under
   `db/validator/` so they coexist with sibling sub-projects in the
   shared `~/synclite/tests/` test root (e.g. `db/javalogger/`,
   `db/dbreader/`, `db/qreader/`).

## Changes

### Core

- [root/core/src/main/java/com/synclite/validator/TestDriver.java](root/core/src/main/java/com/synclite/validator/TestDriver.java)
  - `dbDir = testRoot.resolve("db").resolve("validator")` (was just
    `testRoot.resolve("db")`).
  - New constant `SNAPSHOT_ONLY_SETTLE_POLLS = 6`.
  - `waitForConsolidation` and the streaming variant: completion
    detection now accepts `dstCommitID >= deviceCommitID && dstCommitID > 0`
    (catch-up semantics) **and** treats six consecutive polls reading
    `dstCommitID = -1` as "snapshot-only" success — the destination has
    no `synclite_metadata` row because no CDC ops were applied, so we
    let downstream data-verification handle correctness instead of
    timing out at 10 minutes.

### Web — servlet + JSP

- [root/web/src/main/java/com/synclite/validator/web/ValidateJobConfiguration.java](root/web/src/main/java/com/synclite/validator/web/ValidateJobConfiguration.java)
  - Test root is auto-created (`Files.createDirectories(testRootPath)`)
    instead of failing with "does not exist".
  - New optional form parameters `stage-dir` and `work-dir`; when
    absent, defaults to `<testRoot>/stageDir` and `<testRoot>/workDir`.
  - `dbDirPath = <testRoot>/db/validator`.
  - Cleanup now deletes only validator-owned dirs (`db`, `commandDir`,
    `workDir`) — `stageDir` is shared with sibling projects so wiping it
    wholesale would corrupt their state. Per-device staging cleanup is
    already handled by the consolidator at runtime.

- [root/web/src/main/webapp/configureTestJob.jsp](root/web/src/main/webapp/configureTestJob.jsp)
  - Default test root changed from `~/synclite/test` to `~/synclite/tests`.
  - `dbPath = testRoot/db/validator`.
  - New input fields `stage-dir` and `work-dir` (pre-populated with the
    resolved defaults, both editable — previously the test-root field was
    `readonly`).

## Compatibility

- Existing validator runs that depended on the **exact-equality** stop
  condition (`deviceCommitID == dstCommitID`) will see no behavior
  change in the steady state — `>=` only relaxes the check when the
  destination has already advanced past the device watermark. The
  snapshot-only branch only fires when the destination row is genuinely
  absent.
- Old validator jobs that wrote to `~/synclite/test/db/...` will need to
  point at the new `~/synclite/tests/db/validator/...` layout (or just
  let the new defaults pick it up).

## Naming & packaging refresh

- Dependency `<artifactId>synclite-logger</artifactId>` updated to `synclite`.
- `.classpath` now references `synclite-oss.jar` (was `synclite-logger-oss.jar`).
- Local `<revision>oss</revision>` property added so `mvn install` builds without `-Drevision=...`.
